### PR TITLE
Add SSH access to macOS VM

### DIFF
--- a/services/macos/compose.yaml
+++ b/services/macos/compose.yaml
@@ -15,6 +15,7 @@ services:
       RAM_SIZE: 12G
       CPU_CORES: "6"
       CPU_MODEL: Skylake-Client-v4
+      NETWORK: "user"
     devices:
       - /dev/kvm
       - /dev/net/tun
@@ -25,6 +26,7 @@ services:
     stop_grace_period: 2m
     ports:
       - 8006:8006
+      - 2222:22
     networks:
       homelab-network:
         ipv4_address: 172.20.0.26


### PR DESCRIPTION
## Summary

Enable SSH connectivity to the macOS VM guest from code-server terminal.

## Changes

- Add port mapping `2222:22` for SSH access
- Add `NETWORK: "user"` environment variable for QEMU user-mode networking

## Setup Required After Merge

1. Restart the macOS container
2. Enable Remote Login in macOS: **System Settings** → **General** → **Sharing** → **Remote Login**
3. Connect from code-server: `ssh -p 2222 <user>@<host-ip>`

## Test Plan

- [ ] Restart macOS container after deploying changes
- [ ] Verify macOS boots via web UI (macos.gryta.eu)
- [ ] Enable Remote Login in macOS System Settings
- [ ] Test SSH from code-server terminal: `ssh -p 2222 <user>@<truenas-ip>`
- [ ] Set up SSH key authentication for passwordless access

## Technical Details

The dockurr/macos container uses QEMU with user-mode networking. The `NETWORK: "user"` setting enables port forwarding from the Docker container to the QEMU guest. Without this, Docker port mappings only reach the container, not the macOS guest running inside QEMU.

If the basic port mapping doesn't work, alternatives include:
- Adding explicit QEMU `ARGUMENTS` for hostfwd
- Using DHCP/macvlan mode to give macOS its own network IP