### PR TITLE
Add Navidrome music server

### DIFF
--- a/docs/networks.md
+++ b/docs/networks.md
@@ -44,6 +44,7 @@ Main application network for all services.
 | Roundcube | roundcube | 172.20.0.104 |
 | Mailserver | mailserver | 172.20.0.105 |
 | Jellyseerr | jellyseerr | 172.20.0.106 |
+| Navidrome | navidrome | 172.20.0.107 |
 | OpenFoodFacts | openfoodfacts-server | 172.20.0.110 |
 | | openfoodfacts-db | 172.20.0.111 |
 | | openfoodfacts-redis | 172.20.0.112 |

--- a/services/navidrome/.env
+++ b/services/navidrome/.env
@@ -1,0 +1,2 @@
+# Navidrome configuration
+# No secrets required - Navidrome handles auth internally

--- a/services/navidrome/compose.yaml
+++ b/services/navidrome/compose.yaml
@@ -1,0 +1,59 @@
+services:
+  navidrome:
+    image: deluan/navidrome:latest
+    container_name: navidrome
+    restart: unless-stopped
+    labels:
+      - traefik.enable=true
+      # Priority: API router (higher) takes precedence for /rest/* paths
+      - traefik.http.routers.navidrome-api.priority=100
+      - traefik.http.routers.navidrome.priority=10
+      # ==========================================
+      # SECURE ROUTER (Web UI - Requires Authentik)
+      # ==========================================
+      - traefik.http.routers.navidrome.rule=Host(`navidrome.gryta.eu`)
+      - traefik.http.routers.navidrome.entrypoints=websecure
+      - traefik.http.routers.navidrome.tls.certresolver=le
+      - traefik.http.routers.navidrome.service=navidrome
+      - traefik.http.routers.navidrome.middlewares=authentik-forward-auth@file
+      # ==========================================
+      # API ROUTER (Subsonic API - No Authentik)
+      # ==========================================
+      - traefik.http.routers.navidrome-api.rule=Host(`navidrome.gryta.eu`) && PathPrefix(`/rest`)
+      - traefik.http.routers.navidrome-api.entrypoints=websecure
+      - traefik.http.routers.navidrome-api.tls.certresolver=le
+      - traefik.http.routers.navidrome-api.service=navidrome
+      # ==========================================
+      # SERVICE CONFIG
+      # ==========================================
+      - traefik.http.services.navidrome.loadbalancer.server.port=4533
+    networks:
+      homelab-network:
+        ipv4_address: 172.20.0.107
+    volumes:
+      - navidrome_data:/data
+      - navidrome_music:/music:ro
+    environment:
+      - ND_SCANSCHEDULE=1h
+      - ND_LOGLEVEL=info
+      - ND_SESSIONTIMEOUT=24h
+      - ND_BASEURL=
+    user: "1000:1000"
+
+volumes:
+  navidrome_data:
+    driver: local
+    driver_opts:
+      type: none
+      o: bind
+      device: /mnt/quick/apps/volumes/navidrome/data
+  navidrome_music:
+    driver: local
+    driver_opts:
+      type: none
+      o: bind
+      device: /mnt/archive/media/All/Music
+
+networks:
+  homelab-network:
+    external: true

--- a/services/navidrome/volume.sh
+++ b/services/navidrome/volume.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+QUICK="/mnt/quick/apps/volumes"
+mkdir -p "$QUICK/navidrome/data"
+chown -R 1000:1000 "$QUICK/navidrome"


### PR DESCRIPTION
## Summary
- Add Navidrome self-hosted music streaming server
- Dual-router Traefik config: Authentik SSO for web UI, open `/rest/*` API for mobile apps
- Integrates with existing Lidarr-managed music library at `/mnt/archive/media/All/Music`

## Deployment Plan

### 1. Run volume setup (on TrueNAS host)
```bash
bash /path/to/services/navidrome/volume.sh
```

### 2. Deploy via Dockge
Start the navidrome stack from Dockge UI

### 3. Initial setup
1. Access `https://navidrome.gryta.eu` (goes through Authentik)
2. Create Navidrome admin account on first launch
3. Wait for music library scan to complete

### 4. Mobile app setup (optional)
Connect Subsonic-compatible apps (DSub, Symfonium, Substreamer) using:
- Server: `https://navidrome.gryta.eu`
- Username/Password: Navidrome credentials (API bypasses Authentik)

## Verification
- [ ] Web UI accessible at `https://navidrome.gryta.eu`
- [ ] Authentik SSO working for web access
- [ ] `curl https://navidrome.gryta.eu/rest/ping` responds without Authentik
- [ ] Music library scanned and visible
- [ ] Playback working in web UI

🤖 Generated with [Claude Code](https://claude.ai/code)