### PR TITLE
chore(vscode): update homelab-tools to 1.1.0

### DIFF
--- a/services/vscode/compose.yaml
+++ b/services/vscode/compose.yaml
@@ -47,7 +47,7 @@ services:
   tools:
     labels:
       - traefik.enable=false
-    image: ghcr.io/rgryta/homelab-tools:1.0.0
+    image: ghcr.io/rgryta/homelab-tools:1.1.0
     container_name: tools
     volumes:
       - /opt/tools


### PR DESCRIPTION
## Summary
- Update homelab-tools image from 1.0.0 to 1.1.0

## Changes in 1.1.0
- Multi-stage parallel Docker build
- Scratch-based final image (minimal footprint)
- Static pause binary instead of busybox
- Chrome headless-shell (standalone, no dependencies)
- All tools use static/standalone binaries