### PR TITLE
chore(vscode): bump android-sdk to 1.2.1 and add /mnt mount

### DIFF
--- a/services/vscode/compose.yaml
+++ b/services/vscode/compose.yaml
@@ -20,7 +20,7 @@ services:
   android:
     labels:
       - traefik.enable=false
-    image: ghcr.io/rgryta/android-sdk:1.2.0
+    image: ghcr.io/rgryta/android-sdk:1.2.1
     container_name: android
     volumes:
       - /opt/java/openjdk
@@ -70,6 +70,7 @@ services:
       - vscode_config:/config
       - homelab_stack:/homelab_stack:ro
       - /var/run/docker.sock:/var/run/docker.sock
+      - /mnt:/mnt
     environment:
       - PUID=1000
       - PGID=1000


### PR DESCRIPTION
## Summary
- Bump android-sdk image from 1.2.0 to 1.2.1
- Add `/mnt:/mnt` volume mount to vscode service for host filesystem access

## Test plan
- [x] Verify vscode container starts successfully
- [x] Confirm /mnt is accessible inside the container

🤖 Generated with [Claude Code](https://claude.com/claude-code)