### PR TITLE
chore: update android-sdk to 1.2.2 (glibc fix)

### DIFF
--- a/services/vscode/compose.yaml
+++ b/services/vscode/compose.yaml
@@ -20,7 +20,7 @@ services:
   android:
     labels:
       - traefik.enable=false
-    image: ghcr.io/rgryta/android-sdk:1.2.1
+    image: ghcr.io/rgryta/android-sdk:1.2.2
     container_name: android
     volumes:
       - /opt/java/openjdk


### PR DESCRIPTION
## Summary
- Update android-sdk image from 1.2.1 to 1.2.2
- Fixes glibc compatibility issue (Alpine musl → Ubuntu noble)

🤖 Generated with [Claude Code](https://claude.com/claude-code)