### PR TITLE
chore: pin immich and openfoodfacts image versions

### DIFF
--- a/services/immich/compose.yaml
+++ b/services/immich/compose.yaml
@@ -7,7 +7,7 @@ services:
       - traefik.http.routers.immich.tls.certresolver=le
       - traefik.http.services.immich.loadbalancer.server.port=2283
     container_name: immich_server
-    image: ghcr.io/immich-app/immich-server:${IMMICH_VERSION:-release}
+    image: ghcr.io/immich-app/immich-server:v2
     extends:
       file: hwaccel.transcoding.yml
       service: quicksync
@@ -32,7 +32,7 @@ services:
     labels:
       - traefik.enable=false
     container_name: immich_machine_learning
-    image: ghcr.io/immich-app/immich-machine-learning:${IMMICH_VERSION:-release}-openvino
+    image: ghcr.io/immich-app/immich-machine-learning:v2-openvino
     extends:
       file: hwaccel.ml.yml
       service: openvino

--- a/services/openfoodfacts/compose.yaml
+++ b/services/openfoodfacts/compose.yaml
@@ -30,7 +30,7 @@ services:
       - traefik.http.routers.openfoodfacts.entrypoints=websecure
       - traefik.http.routers.openfoodfacts.tls.certresolver=le
       - traefik.http.services.openfoodfacts.loadbalancer.server.port=8000
-    image: ghcr.io/rgryta/openfoodfacts-api:${IMAGE_TAG:-latest}
+    image: ghcr.io/rgryta/openfoodfacts-api:v1.0.5
     container_name: openfoodfacts-api
     restart: unless-stopped
     environment:
@@ -55,7 +55,7 @@ services:
       retries: 3
       start_period: 10s
   off-updater:
-    image: ghcr.io/rgryta/openfoodfacts-updater:${IMAGE_TAG:-latest}
+    image: ghcr.io/rgryta/openfoodfacts-updater:v1.0.5
     container_name: openfoodfacts-updater
     restart: unless-stopped
     environment:


### PR DESCRIPTION
## Summary
- Immich: Replace env var `${IMMICH_VERSION:-release}` with hardcoded `v2` and `v2-openvino` tags
- OpenFoodFacts: Pin API and Updater from `:latest` to `:v1.0.5`

## Not Changed
- **wellmate.io**: Only has `:main` tag, no version tags available to pin
- **mongo/valkey**: Major version pinning (`:8`, `:9`) is acceptable - provides auto security patches without breaking changes

## Test plan
- [ ] Deploy immich compose and verify containers start with v2 tags
- [ ] Deploy openfoodfacts compose and verify v1.0.5 containers work