### PR TITLE
feat(infra): cap memory on code-server, macos, android

### DIFF
--- a/services/android/compose.yaml
+++ b/services/android/compose.yaml
@@ -20,6 +20,10 @@ services:
       - WEB_VNC=true
       - DATAPARTITION=4g
     restart: unless-stopped
+    deploy:
+      resources:
+        limits:
+          memory: 8G
     networks:
       homelab-network:
         ipv4_address: 172.20.0.27

--- a/services/macos/compose.yaml
+++ b/services/macos/compose.yaml
@@ -24,6 +24,12 @@ services:
     cap_add:
       - NET_ADMIN
     restart: unless-stopped
+    deploy:
+      resources:
+        limits:
+          memory: 20G
+        reservations:
+          memory: 12G
     stop_grace_period: 2m
     networks:
       homelab-network:

--- a/services/vscode/compose.yaml
+++ b/services/vscode/compose.yaml
@@ -108,6 +108,12 @@ services:
       - node
       - tools
     restart: unless-stopped
+    deploy:
+      resources:
+        limits:
+          memory: 12G
+        reservations:
+          memory: 4G
     networks:
       homelab-network:
         ipv4_address: 172.20.0.25


### PR DESCRIPTION
## Problem

The macOS VM container crashes when the host (TrueNAS, 62 GiB) runs out of RAM. Root cause is **host-memory contention**: `code-server`, `macos`, and `android-emulator` had **no memory limit**, while ZFS ARC wants up to 61.5 GiB with no referee. `node_memory_MemAvailable` bottomed at **1.56 GiB** during the analysis window — the near-OOM moment that kills the VM.

Source: Prometheus/cAdvisor, ~16-day window. Only `redpanda` had a limit before this change.

## Change (compose only)

Adds `deploy.resources` memory caps (memory-only — no CPU caps, to avoid throttling builds/VM):

| Service | limit | reservation |
|---|---|---|
| `vscode` (code-server) | 12G | 4G |
| `macos` | 20G | 12G |
| `android` (android-emulator) | 8G | — |

12G lets a full WellMate build run while hard-capping the runaway Gradle-daemon scenario (rare 16 GiB spike). The macOS VM reservation guarantees RAM so a neighbor spike can't starve it.

## Manual post-merge steps (NOT in this PR)

- **ZFS ARC** — cap `zfs_arc_max` to ~24–32 GiB (TrueNAS tunable). Biggest single risk reducer.
- **Gradle daemons** (code-server `~/.gradle/gradle.properties`) — `-Xmx5g`, Kotlin `-Xmx4g`, `workers.max=4`; pin ONE Gradle version + consolidate worktrees to kill daemon proliferation.
- **Grafana alerts** — per-container `working_set > 14e9`; host `MemAvailable < 6e9`.

## Follow-up (rec #6)

Cap remaining spikers later: `immich_machine_learning` (→4.5G), `qbittorrent` (→2.5G), `wellmate-github-runner` (→1.5G), and conservative limits across all containers.

## Deploy note

Per the homelab flow: deploy → let Dockge reformat → reconcile this PR with the running compose → merge. **Draft** until validated on the host.
