### PR TITLE
docs(databases): record bemol as shared DB consumer

### DIFF
--- a/services/databases/README.md
+++ b/services/databases/README.md
@@ -10,6 +10,21 @@ Shared database infrastructure for homelab services.
 | authentik | Authentik IdP |
 | immich | Immich photo management |
 | openfoodfacts | OpenFoodFacts API |
+| bemol | bemol karaoke service |
+
+## Valkey logical databases
+
+Valkey is a single shared instance (`maxmemory 512mb`, `allkeys-lru`). Each
+broker/cache consumer gets a distinct logical DB index to avoid key collisions.
+
+| Index | Service |
+|-------|---------|
+| 1 | BTX |
+| 2 | bemol (Celery broker) |
+
+> bemol uses its index as a Celery **broker** (queue keys have no TTL). Under
+> `allkeys-lru` a memory-pressure eviction can silently drop queued tasks; switch
+> the policy to `volatile-lru` if broker durability becomes a concern.
 
 ## Setup
 


### PR DESCRIPTION
## What

Documents bemol's cutover from local Postgres/Redis to the shared `databases` stack.

- **PostgreSQL:** adds `bemol` (dedicated role + database on `homelab-postgres`) to the consumer table.
- **Valkey:** adds a logical-DB assignment table reserving **db 2** for bemol's Celery broker (db 1 = BTX), preventing future index collisions.
- **Broker caveat:** notes the `allkeys-lru` eviction risk for broker keys and the `volatile-lru` mitigation.

## Context

bemol's local `bemol-postgres` / `bemol-redis` containers were removed; it now connects to `homelab-postgres` (bemol db) and `homelab-valkey` db 2 over homelab-network. The bemol stack's compose/env changes live in the bemol repo; this PR is only the infra-repo documentation footprint. No secrets added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)